### PR TITLE
✨  add interface to allow process-start-by-id

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -60,7 +60,8 @@ export interface IImportFromFileOptions {
 }
 
 export interface IParamStart {
-  key: string;
+  id?: string;
+  key?: string;
   initialToken?: any;
   source?: any;
   isSubProcess?: boolean;


### PR DESCRIPTION
## What did you change?

I added the interfaces necessary to allow for starting a process by its id, not only by its key

Related PRs: https://github.com/process-engine/process_engine/pull/11

## How can others test the changes?

Where before you could only start a process with a `/start`-body like this:
```JSON
{
  "msg": {
    "key": "start"
  }
}
```

you can now also do this:
```JSON
{
  "msg": {
    "id": "facd924b-eb4c-4b50-82c6-41519cbb62d8"
  }
}
```


## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
