### PR TITLE
Remove draft- and latest- flags and add isExecutable to ProcessDef

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "the referencable contracts for metadata",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/entities/process/iprocess_def_entity.ts
+++ b/src/entities/process/iprocess_def_entity.ts
@@ -16,8 +16,7 @@ export interface IProcessDefEntity extends IEntity {
   readonly: boolean;
   version: string;
   counter: number;
-  draft: boolean;
-  latest: boolean;
+  isExecutable: boolean;
   nodeDefCollection: IEntityCollection<INodeDefEntity>;
   flowDefCollection: IEntityCollection<IFlowDefEntity>;
   laneCollection: IEntityCollection<ILaneEntity>;
@@ -31,8 +30,5 @@ export interface IProcessDefEntity extends IEntity {
   start(context: ExecutionContext, params: IParamStart, options?: IPublicGetOptions): Promise<IEntityReference>;
   updateDefinitions(context: ExecutionContext, params?: IParamUpdateDefs): Promise<void>;
   updateBpmn(context: ExecutionContext, xml: string): Promise<any>;
-  getDraft(context: ExecutionContext): Promise<IProcessDefEntity>;
-  getLatest(context: ExecutionContext): Promise<IProcessDefEntity>;
-  publishDraft(context: ExecutionContext): Promise<IProcessDefEntity>;
   equals(processDef: IProcessDefEntity): boolean;
 }


### PR DESCRIPTION
Closes #22 #23

## What did you change?

This will remove the `draft` and `latest` flags and functions from `IProcessDefEntity` and add the `isExecutable` flag to the Entity.

## How can others test the changes?

Since `draft` and `latest` are long removed from any implementations and `isExecutable` is not yet interpreted by the process engine, this really shouldn't affect anything at all.

Even so, in regards to possible feature sensitive releases that may have been released to a customer in the past, this is still marked as a breaking change.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
