### PR TITLE
Add correlationId to ProcessInstanceEntity

### DIFF
--- a/src/entities/process/iprocess_entity.ts
+++ b/src/entities/process/iprocess_entity.ts
@@ -9,6 +9,7 @@ export interface IProcessEntity extends IEntity {
   activeInstances: any;
   allInstances: any;
   boundProcesses: any;
+  correlationId: string;
   getProcessDef(context: ExecutionContext): Promise<IProcessDefEntity>;
   initializeProcess(): Promise<void>;
   start(context: ExecutionContext, params: IParamStart, options?: IPublicGetOptions): Promise<void>;


### PR DESCRIPTION
## What did you change?

Adds the property `correlationId` to the process instance entity.

This requirement came during the implementation of the consumer api for the call activity.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
