### PR TITLE
WIP: Remove processEngineService.start convenience method

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "7.1.0",
+  "version": "8.0.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/iprocess_engine_service.ts
+++ b/src/iprocess_engine_service.ts
@@ -4,7 +4,6 @@ import {IErrorDeserializer, IProcessDefEntity, IUserTaskMessageData} from './ind
 export interface IProcessEngineService {
   config: any;
   initialize(): Promise<void>;
-  start(context: ExecutionContext, data: any, options: IPublicGetOptions): Promise<string>;
   getUserTaskData(context: ExecutionContext, userTaskId: string): Promise<IUserTaskMessageData>;
   executeProcess(context: ExecutionContext, id: string, key: string, initialToken: any, version?: string): Promise<any>;
   createProcessInstance(context: ExecutionContext, processDefinitionId: string, key: string, version?: string): Promise<string>;


### PR DESCRIPTION
## What did you change?

Removes the `start` method from the `IProcessEngineService` interface.

This method was an attempt to duplicate the `execute` method. However, since it completely circumvented messagebus subscription, processes that were started this way were never finished.

Since it is best-practice  to use one of the `execute` methods anyway, the `start` method was removed.

## How can others test the changes?

This should only be an internal change, so backend-wise all should run as before.
For the bpmn studio, this fixes the following issue: https://github.com/process-engine/process_engine/issues/91

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
