### PR TITLE
Feature/provide process as xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "14.1.0",
+  "version": "15.0.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/storage/index.ts
+++ b/src/runtime/storage/index.ts
@@ -4,4 +4,4 @@ export * from './iprocess_definition_repository';
 export * from './iprocess_model_service';
 export * from './itimer_repository';
 export * from './itimer_service';
-export * from './process_definition_from_repository';
+export * from './process_definition_raw';

--- a/src/runtime/storage/iprocess_definition_repository.ts
+++ b/src/runtime/storage/iprocess_definition_repository.ts
@@ -3,4 +3,5 @@ import {ProcessDefinitionRaw} from './process_definition_raw';
 export interface IProcessDefinitionRepository {
   persistProcessDefinitions(name: string, xml: string, overwriteExisting?: boolean): Promise<void>;
   getProcessDefinitions(): Promise<Array<ProcessDefinitionRaw>>;
+  getProcessDefinitionByName(definitionId: string): Promise<ProcessDefinitionRaw>;
 }

--- a/src/runtime/storage/iprocess_definition_repository.ts
+++ b/src/runtime/storage/iprocess_definition_repository.ts
@@ -1,6 +1,6 @@
-import {ProcessDefinitionFromRepository} from './process_definition_from_repository';
+import {ProcessDefinitionRaw} from './process_definition_raw';
 
 export interface IProcessDefinitionRepository {
   persistProcessDefinitions(name: string, xml: string, overwriteExisting?: boolean): Promise<void>;
-  getProcessDefinitions(): Promise<Array<ProcessDefinitionFromRepository>>;
+  getProcessDefinitions(): Promise<Array<ProcessDefinitionRaw>>;
 }

--- a/src/runtime/storage/iprocess_model_service.ts
+++ b/src/runtime/storage/iprocess_model_service.ts
@@ -1,9 +1,11 @@
 import {Model} from '../..';
+import {ProcessDefinitionRaw} from './process_definition_raw';
 
 import {IExecutionContextFacade} from '../engine/index';
 
 export interface IProcessModelService {
   persistProcessDefinitions(executionContextFacade: IExecutionContextFacade, name: string, xml: string, overwriteExisting?: boolean): Promise<void>;
   getProcessModelById(executionContextFacade: IExecutionContextFacade, processModelId: string): Promise<Model.Types.Process>;
+  getProcessDefinitionAsXmlById(executionContextFacade: IExecutionContextFacade, processModelId: string): Promise<ProcessDefinitionRaw>;
   getProcessModels(executionContextFacade: IExecutionContextFacade): Promise<Array<Model.Types.Process>>;
 }

--- a/src/runtime/storage/process_definition_raw.ts
+++ b/src/runtime/storage/process_definition_raw.ts
@@ -1,4 +1,4 @@
-export class ProcessDefinitionFromRepository {
+export class ProcessDefinitionRaw {
   public name: string;
   public xml: string;
 }


### PR DESCRIPTION
Closes #46 

## What did you change?

- Rename `ProcessDefinitionFromRepository` to `ProcessDefinitionRaw`, since that object will now be used by the management api aswell
- Add methods for retrieving a processes' raw xml
  - `getProcessDefinitionAsXmlById` in the `ProcessModelService`
  - `getProcessDefinitionByName` in the `ProcessDefinitionRepository`

## How can others test the changes?

Implement the interfaces.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
