### PR TITLE
Feature/add support for querying active correlations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "15.0.0",
+  "version": "16.0.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/storage/icorrelation_service.ts
+++ b/src/runtime/storage/icorrelation_service.ts
@@ -1,0 +1,6 @@
+import {IExecutionContextFacade} from '../engine/index';
+import {Correlation} from '../types/index';
+
+export interface ICorrelationService {
+  getAllActiveCorrelations(executionContextFacade: IExecutionContextFacade): Promise<Array<Correlation>>;
+}

--- a/src/runtime/storage/iflow_node_instance_repository.ts
+++ b/src/runtime/storage/iflow_node_instance_repository.ts
@@ -1,10 +1,11 @@
-import {FlowNodeInstance, ProcessToken} from './../types';
+import {FlowNodeInstance, FlowNodeInstanceState, ProcessToken} from './../types';
 
 export interface IFlowNodeInstanceRepository {
   persistOnEnter(token: ProcessToken, flowNodeId: string, flowNodeInstanceId: string): Promise<FlowNodeInstance>;
   persistOnExit(token: ProcessToken, flowNodeId: string, flowNodeInstanceId: string): Promise<FlowNodeInstance>;
   suspend(token: ProcessToken, flowNodeInstanceId: string, correlationHash?: string): Promise<FlowNodeInstance>;
   resume(flowNodeInstanceId: string): Promise<FlowNodeInstance>;
+  queryByState(state: FlowNodeInstanceState): Promise<Array<FlowNodeInstance>>;
   queryByCorrelation(correlationId: string): Promise<Array<FlowNodeInstance>>;
   queryByProcessModel(processModelId: string): Promise<Array<FlowNodeInstance>>;
   querySuspendedByProcessModel(processModelId: string): Promise<Array<FlowNodeInstance>>;

--- a/src/runtime/storage/iflow_node_instance_service.ts
+++ b/src/runtime/storage/iflow_node_instance_service.ts
@@ -1,6 +1,5 @@
-import {FlowNodeInstance, ProcessToken} from './../types/index';
-
 import {IExecutionContextFacade} from '../engine/index';
+import {FlowNodeInstance, ProcessToken} from '../types/index';
 
 export interface IFlowNodeInstanceService {
   persistOnEnter(executionContextFacade: IExecutionContextFacade,

--- a/src/runtime/storage/index.ts
+++ b/src/runtime/storage/index.ts
@@ -1,3 +1,4 @@
+export * from './icorrelation_service';
 export * from './iflow_node_instance_repository';
 export * from './iflow_node_instance_service';
 export * from './iprocess_definition_repository';

--- a/src/runtime/types/correlation.ts
+++ b/src/runtime/types/correlation.ts
@@ -4,5 +4,4 @@ export class Correlation {
   public id: string;
   public processModelId: string;
   public state: FlowNodeInstanceState;
-  public isSuspended: boolean;
 }

--- a/src/runtime/types/correlation.ts
+++ b/src/runtime/types/correlation.ts
@@ -1,0 +1,8 @@
+import {FlowNodeInstanceState} from './flow_node_instance_state';
+
+export class Correlation {
+  public id: string;
+  public processModelId: string;
+  public state: FlowNodeInstanceState;
+  public isSuspended: boolean;
+}

--- a/src/runtime/types/flow_node_instance.ts
+++ b/src/runtime/types/flow_node_instance.ts
@@ -1,8 +1,10 @@
+import {FlowNodeInstanceState} from './flow_node_instance_state';
 import {ProcessToken} from './process_token';
 
 export class FlowNodeInstance {
   public id: string;
   public flowNodeId: string;
   public token: ProcessToken;
+  public state: FlowNodeInstanceState = FlowNodeInstanceState.running;
   public isSuspended: boolean;
 }

--- a/src/runtime/types/flow_node_instance_state.ts
+++ b/src/runtime/types/flow_node_instance_state.ts
@@ -1,0 +1,6 @@
+export enum FlowNodeInstanceState {
+  running = 1,
+  finished = 2,
+  terminated = 3,
+  error = 4,
+}

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -1,3 +1,5 @@
+export * from './correlation';
+export * from './flow_node_instance_state';
 export * from './flow_node_instance';
 export * from './process_token';
 export * from './timer_type';


### PR DESCRIPTION
Closes #47 

## What did you change?

- Add `state` property to flow node instances, which detail the state a current flow node instance is in. Current supported states are:
  - running: Set during `persistOnEnter` -> The flow node instance is running
  - finished: Set during `persistOnExit` -> The flow node instance has successfully finished
  - terminated: Not used yet -> The flow node instance was terminated by a termination end event
  - error: Not used yet -> The flow node instance was prematurely interrupted due to an error
- Add `ICorrelationService` interface for supporting correlation related operations on the persistence layer
  - Add a corresponding type `Correlation` to the runtime object types, which encapsulates all relevant information about a correlation

## How can others test the changes?

Use the mentioned interfaces.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
