### PR TITLE
Process definitions instead of process model

### DIFF
--- a/src/runtime/storage/iprocess_model_service.ts
+++ b/src/runtime/storage/iprocess_model_service.ts
@@ -6,6 +6,6 @@ import {IExecutionContextFacade} from '../engine/index';
 export interface IProcessModelService {
   persistProcessDefinitions(executionContextFacade: IExecutionContextFacade, name: string, xml: string, overwriteExisting?: boolean): Promise<void>;
   getProcessModelById(executionContextFacade: IExecutionContextFacade, processModelId: string): Promise<Model.Types.Process>;
-  getProcessDefinitionAsXmlById(executionContextFacade: IExecutionContextFacade, processModelId: string): Promise<ProcessDefinitionRaw>;
+  getProcessDefinitionAsXmlByName(executionContextFacade: IExecutionContextFacade, name: string): Promise<ProcessDefinitionRaw>;
   getProcessModels(executionContextFacade: IExecutionContextFacade): Promise<Array<Model.Types.Process>>;
 }


### PR DESCRIPTION
## What did you change?

* renamed `getProcessDefinitionAsXmlById ` to `getProcessDefinitionAsXmlByName` to reflect the change of entity
   * the former parameter for `processModelId` now expects a name - independent from the process model

## How can others test the changes?

All integration tests in meta repositories should run successfully: 

* https://github.com/process-engine/management_api_meta/pull/6
* https://github.com/process-engine/consumer_api_meta/pull/40
* https://github.com/process-engine/deployment_api_meta/pull/3
* https://github.com/process-engine/process_engine_meta/pull/122

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
