### PR TITLE
Feature/reactivate terminate end event

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "21.0.0",
+  "version": "22.0.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/engine/iflow_node_handler.ts
+++ b/src/runtime/engine/iflow_node_handler.ts
@@ -7,7 +7,12 @@ import {
 } from './index';
 
 export interface IFlowNodeHandler<TFlowNode extends Model.Base.FlowNode> {
-  flowNodeInstanceId: string;
+  /**
+   * Gets the instance ID of the FlowNode that this handler is responsible for.
+   *
+   * @returns The instance ID of the corresponding FlowNode.
+   */
+  getInstanceId(): string;
   execute(flowNode: TFlowNode,
           token: Runtime.Types.ProcessToken,
           processTokenFacade: IProcessTokenFacade,

--- a/src/runtime/engine/iflow_node_handler.ts
+++ b/src/runtime/engine/iflow_node_handler.ts
@@ -7,6 +7,7 @@ import {
 } from './index';
 
 export interface IFlowNodeHandler<TFlowNode extends Model.Base.FlowNode> {
+  flowNodeInstanceId: string;
   execute(flowNode: TFlowNode,
           token: Runtime.Types.ProcessToken,
           processTokenFacade: IProcessTokenFacade,

--- a/src/runtime/messages/end_event_reached.ts
+++ b/src/runtime/messages/end_event_reached.ts
@@ -1,10 +1,11 @@
-export class EndEventReachedMessage {
+import {EventMessageType} from './event_message_types';
+import {EventReachedMessage} from './event_reached';
 
-  public endEventId: string;
-  public tokenPayload: string;
+export class EndEventReachedMessage extends EventReachedMessage {
 
   constructor(endEventId: string, tokenPayload: any) {
-    this.endEventId = endEventId;
-    this.tokenPayload = tokenPayload;
+    super(endEventId, tokenPayload);
+
+    this._messageType = EventMessageType.end;
   }
 }

--- a/src/runtime/messages/event_message_types.ts
+++ b/src/runtime/messages/event_message_types.ts
@@ -1,0 +1,4 @@
+export enum EventMessageType {
+  end = 'end',
+  terminate = 'terminate'
+}

--- a/src/runtime/messages/event_reached.ts
+++ b/src/runtime/messages/event_reached.ts
@@ -12,7 +12,7 @@ export abstract class EventReachedMessage {
   }
 
   public get eventId(): string {
-    return this.eventId;
+    return this._eventId;
   }
 
   public get tokenPayload(): any {

--- a/src/runtime/messages/event_reached.ts
+++ b/src/runtime/messages/event_reached.ts
@@ -1,0 +1,25 @@
+import {EventMessageType} from './event_message_types';
+
+export abstract class EventReachedMessage {
+
+  protected _eventId: string;
+  protected _tokenPayload: any;
+  protected _messageType: EventMessageType;
+
+  constructor(eventId: string, tokenPayload: any) {
+    this._eventId = eventId;
+    this._tokenPayload = tokenPayload;
+  }
+
+  public get eventId(): string {
+    return this.eventId;
+  }
+
+  public get tokenPayload(): any {
+    return this._tokenPayload;
+  }
+
+  public get messageType(): EventMessageType {
+    return this._messageType;
+  }
+}

--- a/src/runtime/messages/index.ts
+++ b/src/runtime/messages/index.ts
@@ -1,1 +1,4 @@
+export * from './event_reached';
 export * from './end_event_reached';
+export * from './event_message_types';
+export * from './terminate_end_event_reached';

--- a/src/runtime/messages/terminate_end_event_reached.ts
+++ b/src/runtime/messages/terminate_end_event_reached.ts
@@ -1,0 +1,11 @@
+import {EventMessageType} from './event_message_types';
+import {EventReachedMessage} from './event_reached';
+
+export class TerminateEndEventReachedMessage extends EventReachedMessage{
+
+  constructor(terminateEndEventId: string, tokenPayload: any) {
+    super(terminateEndEventId, tokenPayload);
+
+    this._messageType = EventMessageType.terminate;
+  }
+}

--- a/src/runtime/storage/iflow_node_instance_repository.ts
+++ b/src/runtime/storage/iflow_node_instance_repository.ts
@@ -4,6 +4,7 @@ export interface IFlowNodeInstanceRepository {
   persistOnEnter(token: ProcessToken, flowNodeId: string, flowNodeInstanceId: string): Promise<FlowNodeInstance>;
   persistOnExit(token: ProcessToken, flowNodeId: string, flowNodeInstanceId: string): Promise<FlowNodeInstance>;
   persistOnError(token: ProcessToken, flowNodeId: string, flowNodeInstanceId: string, error: Error): Promise<FlowNodeInstance>;
+  persistOnTerminate(token: ProcessToken, flowNodeId: string, flowNodeInstanceId: string): Promise<FlowNodeInstance>;
   suspend(token: ProcessToken, flowNodeInstanceId: string, correlationHash?: string): Promise<FlowNodeInstance>;
   resume(flowNodeInstanceId: string): Promise<FlowNodeInstance>;
   queryByState(state: FlowNodeInstanceState): Promise<Array<FlowNodeInstance>>;

--- a/src/runtime/storage/iflow_node_instance_service.ts
+++ b/src/runtime/storage/iflow_node_instance_service.ts
@@ -11,13 +11,18 @@ export interface IFlowNodeInstanceService {
                 token: ProcessToken,
                 flowNodeId: string,
                 flowNodeInstanceId: string,
-                ): Promise<FlowNodeInstance>;
+               ): Promise<FlowNodeInstance>;
   persistOnError(executionContextFacade: IExecutionContextFacade,
                  token: ProcessToken,
                  flowNodeId: string,
                  flowNodeInstanceId: string,
                  error: Error,
-              ): Promise<FlowNodeInstance>;
+                ): Promise<FlowNodeInstance>;
+  persistOnTerminate(executionContextFacade: IExecutionContextFacade,
+                     token: ProcessToken,
+                     flowNodeId: string,
+                     flowNodeInstanceId: string,
+                    ): Promise<FlowNodeInstance>;
   suspend(executionContextFacade: IExecutionContextFacade,
           token: ProcessToken,
           flowNodeInstanceId: string,


### PR DESCRIPTION
## What did you change?

- Add `persistOnTerminate` to the `IFlowNodeInstanceService` and `IFlowNodeInstanceRepository` interfaces
- Add a base type for `EventReachedMessage` and implement two inheriting message classes for `EndEventReachedMessage` and `TerminateEndEventReachedMessage`
  - This was done to enable a better illustration of the gravity of the TerminateEndEvent, in comparison to the regular EndEvent

## How can others test the changes?

Run the Integrationtest for the TerminateEndEvent.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
