### PR TITLE
Revert "✨ Add a State Flag for the Correlation"

### DIFF
--- a/src/runtime/storage/icorrelation_repository.ts
+++ b/src/runtime/storage/icorrelation_repository.ts
@@ -1,6 +1,5 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
-import {CorrelationState} from '../types/correlation_state';
 import {CorrelationFromRepository} from '../types/index';
 
 /**
@@ -93,38 +92,10 @@ export interface ICorrelationRepository {
   getSubprocessesForProcessInstance(processInstanceId: string): Promise<Array<CorrelationFromRepository>>;
 
   /**
-   * Returns a list of all Correlations in the specified state.
-   *
-   * @async
-   * @param   state       The state by which to retrieve the correlations.
-   * @returns             The retrieved correlations.
-   */
-  getCorrelationsByState(state: CorrelationState): Promise<Array<CorrelationFromRepository>>;
-
-  /**
    * Removes all correlations with a specific ProcessModelId.
    *
    * @async
    * @param   processModelId The ID of the processModel, by which correlations should be removed.
    */
   deleteCorrelationByProcessModelId(correlationId: string): Promise<void>;
-
-  /**
-   * Finishes the given correlation.
-   *
-   * @async
-   * @param   correlationId   The ID of the Correlation to finish.
-   * @throws  NotFoundError  When no matching correlation was found.
-   */
-  finishCorrelation(correlationId: string): Promise<void>;
-
-  /**
-   * Finishes the given correlation with an error.
-   *
-   * @async
-   * @param   correlationId   The ID of the Correlation to finish erroneously.
-   * @param   error           The error that occurred.
-   * @throws  NotFoundError  When no matching correlation was found.
-   */
-  finishWithError(correlationId: string, error: Error): Promise<void>;
 }

--- a/src/runtime/storage/icorrelation_service.ts
+++ b/src/runtime/storage/icorrelation_service.ts
@@ -93,7 +93,7 @@ export interface ICorrelationService {
    * ProcessInstanceId.
    *
    * @async
-   * @param  processInstanceId The ID of the ProcessInstance for which to retrieve
+   * @param   processInstanceId The ID of the ProcessInstance for which to retrieve
    *                            the SubProcess-Correlations.
    * @returns                   The retrieved Correlations.
    *                            If none are found, an empty Array is returned.
@@ -104,25 +104,7 @@ export interface ICorrelationService {
    * Removes all correlations with a specific ProcessModelId.
    *
    * @async
-   * @param  processModelId The ID of the processModel, by which correlations should be removed.
+   * @param    processModelId The ID of the processModel, by which correlations should be removed.
    */
   deleteCorrelationByProcessModelId(processModelId: string): Promise<void>;
-  /**
-   * Finishes the given correlation.
-   *
-   * @async
-   * @param  correlationId   The ID of the Correlation to finish.
-   * @throws NotFoundError  When no matching correlation was found.
-   */
-  finishCorrelation(correlationId: string): Promise<void>;
-
-  /**
-   * Finishes the given correlation with an error.
-   *
-   * @async
-   * @param  correlationId   The ID of the Correlation to finish erroneously.
-   * @param  error           The error that occurred.
-   * @throws NotFoundError  When no matching correlation was found.
-   */
-  finishWithError(correlationId: string, error: Error): Promise<void>;
 }

--- a/src/runtime/types/correlation.ts
+++ b/src/runtime/types/correlation.ts
@@ -1,7 +1,7 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
-import {CorrelationProcessInstance} from './correlation_process_instance';
-import {CorrelationState} from './correlation_state';
+import {CorrelationProcessModel} from './correlation_process_model';
+import {FlowNodeInstanceState} from './flow_node_instance_state';
 
 /**
  * Describes a Correlation.
@@ -9,8 +9,7 @@ import {CorrelationState} from './correlation_state';
 export class Correlation {
   public id: string;
   public identity: IIdentity;
-  public processModels: Array<CorrelationProcessInstance>;
-  public state: CorrelationState;
-  public error: Error;
+  public processModels: Array<CorrelationProcessModel>;
+  public state: FlowNodeInstanceState;
   public createdAt?: Date;
 }

--- a/src/runtime/types/correlation_from_repository.ts
+++ b/src/runtime/types/correlation_from_repository.ts
@@ -1,7 +1,5 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
-import {CorrelationState} from './correlation_state';
-
 /**
  * Describes a Correlation, as it is stored in the CorrelationRepository.
  */
@@ -11,8 +9,6 @@ export class CorrelationFromRepository {
   public processModelId: string;
   public processInstanceId: string;
   public parentProcessInstanceId?: string;
-  public state: CorrelationState;
-  public error: Error;
   public identity: IIdentity;
   public createdAt: Date;
   public updatedAt: Date;

--- a/src/runtime/types/correlation_process_model.ts
+++ b/src/runtime/types/correlation_process_model.ts
@@ -1,16 +1,15 @@
-import {CorrelationState} from './correlation_state';
+import {FlowNodeInstanceState} from './flow_node_instance_state';
 
 /**
- * Describes a ProcessInstance within a Correlation.
+ * Describes a ProcessModel within a Correlation.
  */
-export class CorrelationProcessInstance {
+export class CorrelationProcessModel {
   public processDefinitionName: string;
   public hash: string;
   public xml: string;
   public processModelId: string;
   public processInstanceId?: string;
   public parentProcessInstanceId?: string;
-  public state: CorrelationState;
-  public error: Error;
+  public state: FlowNodeInstanceState;
   public createdAt?: Date;
 }

--- a/src/runtime/types/correlation_state.ts
+++ b/src/runtime/types/correlation_state.ts
@@ -1,8 +1,0 @@
-/**
- * Lists the various states that a Correlation can be in.
- */
-export enum CorrelationState {
-  running = 'running',
-  finished = 'finished',
-  error = 'error',
-}

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -1,6 +1,5 @@
 export * from './correlation_from_repository';
-export * from './correlation_process_instance';
-export * from './correlation_state';
+export * from './correlation_process_model';
 export * from './correlation';
 export * from './flow_node_instance_state';
 export * from './flow_node_instance';


### PR DESCRIPTION
According to @robpal94 This branch is currently not working in the runtime.

Therefore, this merge is being reverted, since the develop would now contain changes from a broken branch.

I did not think it necessary to mention such a thing, but merging broken branches is an absolute **NO GO**.

I do not want to see that again!