### PR TITLE
🐛 Fix timer expression parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "39.0.0",
+  "version": "39.1.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/engine/itimer_facade.ts
+++ b/src/runtime/engine/itimer_facade.ts
@@ -16,8 +16,6 @@ export interface ITimerFacade {
    * @param   flowNode           The FlowNode to which to attach the timer.
    * @param   timerType          The type of the timer (cycle, duration, etc).
    * @param   timerValue         The value of the timer.
-   * @param   processTokenFacade The ProcessTokenFacade to use to retrieve
-   *                             token values for timer expressions.
    * @param   callback           The function to call, after the timer has elapsed.
    * @returns                    A Subscription on the event aggreator,
    *                             which can be used to wait for the timer to elapse.
@@ -26,7 +24,6 @@ export interface ITimerFacade {
     flowNode: Model.Base.FlowNode,
     timerType: TimerDefinitionType,
     timerValue: string,
-    processTokenFacade: IProcessTokenFacade,
     callback: Function,
   ): Subscription;
 

--- a/src/runtime/engine/itimer_facade.ts
+++ b/src/runtime/engine/itimer_facade.ts
@@ -1,22 +1,37 @@
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {Model, TimerDefinitionType} from '@process-engine/process_engine_contracts';
 
+import {TimerEventDefinition} from '../../model/event_definitions/timer_event_definition';
+
 /**
  * Handles the creation and resolution of timers.
  */
 export interface ITimerFacade {
 
   /**
-   * Initializes a new timer that will be attached to the given flowNode.
+   * Initializes a new timer for the given FlowNode, using the given type and
+   * value as a baseline.
    *
    * @param   flowNode   The FlowNode to which to attach the timer.
    * @param   timerType  The type of the timer (cycle, duration, etc).
    * @param   timerValue The value of the timer (interval, duration, etc).
    * @param   callback   The function to call, after the timer has elapsed.
-   * @returns            A Subscription on the event aggreator, which can be used
-   *                     to wait for the timer to elapse.
+   * @returns            A Subscription on the event aggreator,
+   *                     which can be used to wait for the timer to elapse.
    */
   initializeTimer(flowNode: Model.Base.FlowNode, timerType: TimerDefinitionType, timerValue: string, callback: Function): Subscription;
+
+  /**
+   * Initializes a new timer for the given FlowNode from the given
+   * timerDefinition.
+   *
+   * @param   flowNode        The FlowNode to which to attach the timer.
+   * @param   timerDefinition The timer definition from which to build the timer.
+   * @param   callback        The function to call, after the timer has elapsed.
+   * @returns                 A Subscription on the event aggreator,
+   *                          which can be used to wait for the timer to elapse.
+   */
+  initializeTimerFromDefinition(flowNode: Model.Base.FlowNode, timerDefinition: TimerEventDefinition, callback: Function): Subscription;
 
   /**
    * Takes an event definition and parsed it into a comprehensive

--- a/src/runtime/engine/itimer_facade.ts
+++ b/src/runtime/engine/itimer_facade.ts
@@ -2,7 +2,7 @@ import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {Model, TimerDefinitionType} from '@process-engine/process_engine_contracts';
 
 import {TimerEventDefinition} from '../../model/event_definitions/timer_event_definition';
-import {ProcessToken} from '../types/process_token';
+import {IProcessTokenFacade} from './iprocess_token_facade';
 
 /**
  * Handles the creation and resolution of timers.
@@ -13,20 +13,20 @@ export interface ITimerFacade {
    * Initializes a new timer for the given FlowNode, using the given type and
    * value as a baseline.
    *
-   * @param   flowNode   The FlowNode to which to attach the timer.
-   * @param   timerType  The type of the timer (cycle, duration, etc).
-   * @param   timerValue The value of the timer (interval, duration, etc).
-   * @param   token      The ProcessToken from which to get values for
-   *                     timer expressions.
-   * @param   callback   The function to call, after the timer has elapsed.
-   * @returns            A Subscription on the event aggreator,
-   *                     which can be used to wait for the timer to elapse.
+   * @param   flowNode           The FlowNode to which to attach the timer.
+   * @param   timerType          The type of the timer (cycle, duration, etc).
+   * @param   timerValue         The value of the timer.
+   * @param   processTokenFacade The ProcessTokenFacade to use to retrieve
+   *                             token values for timer expressions.
+   * @param   callback           The function to call, after the timer has elapsed.
+   * @returns                    A Subscription on the event aggreator,
+   *                             which can be used to wait for the timer to elapse.
    */
   initializeTimer(
     flowNode: Model.Base.FlowNode,
     timerType: TimerDefinitionType,
     timerValue: string,
-    token: ProcessToken,
+    processTokenFacade: IProcessTokenFacade,
     callback: Function,
   ): Subscription;
 
@@ -34,18 +34,18 @@ export interface ITimerFacade {
    * Initializes a new timer for the given FlowNode from the given
    * timerDefinition.
    *
-   * @param   flowNode        The FlowNode to which to attach the timer.
-   * @param   timerDefinition The timer definition from which to build the timer.
-   * @param   token           The ProcessToken from which to get values for
-   *                          timer expressions.
-   * @param   callback        The function to call, after the timer has elapsed.
-   * @returns                 A Subscription on the event aggreator,
-   *                          which can be used to wait for the timer to elapse.
+   * @param   flowNode           The FlowNode to which to attach the timer.
+   * @param   timerDefinition    The timer definition from which to build the timer.
+   * @param   processTokenFacade The ProcessTokenFacade to use to retrieve
+   *                             token values for timer expressions.
+   * @param   callback           The function to call, after the timer has elapsed.
+   * @returns                    A Subscription on the event aggreator,
+   *                             which can be used to wait for the timer to elapse.
    */
   initializeTimerFromDefinition(
     flowNode: Model.Base.FlowNode,
     timerDefinition: TimerEventDefinition,
-    token: ProcessToken,
+    processTokenFacade: IProcessTokenFacade,
     callback: Function,
   ): Subscription;
 

--- a/src/runtime/engine/itimer_facade.ts
+++ b/src/runtime/engine/itimer_facade.ts
@@ -2,6 +2,7 @@ import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {Model, TimerDefinitionType} from '@process-engine/process_engine_contracts';
 
 import {TimerEventDefinition} from '../../model/event_definitions/timer_event_definition';
+import {ProcessToken} from '../types/process_token';
 
 /**
  * Handles the creation and resolution of timers.
@@ -15,11 +16,19 @@ export interface ITimerFacade {
    * @param   flowNode   The FlowNode to which to attach the timer.
    * @param   timerType  The type of the timer (cycle, duration, etc).
    * @param   timerValue The value of the timer (interval, duration, etc).
+   * @param   token      The ProcessToken from which to get values for
+   *                     timer expressions.
    * @param   callback   The function to call, after the timer has elapsed.
    * @returns            A Subscription on the event aggreator,
    *                     which can be used to wait for the timer to elapse.
    */
-  initializeTimer(flowNode: Model.Base.FlowNode, timerType: TimerDefinitionType, timerValue: string, callback: Function): Subscription;
+  initializeTimer(
+    flowNode: Model.Base.FlowNode,
+    timerType: TimerDefinitionType,
+    timerValue: string,
+    token: ProcessToken,
+    callback: Function,
+  ): Subscription;
 
   /**
    * Initializes a new timer for the given FlowNode from the given
@@ -27,11 +36,18 @@ export interface ITimerFacade {
    *
    * @param   flowNode        The FlowNode to which to attach the timer.
    * @param   timerDefinition The timer definition from which to build the timer.
+   * @param   token           The ProcessToken from which to get values for
+   *                          timer expressions.
    * @param   callback        The function to call, after the timer has elapsed.
    * @returns                 A Subscription on the event aggreator,
    *                          which can be used to wait for the timer to elapse.
    */
-  initializeTimerFromDefinition(flowNode: Model.Base.FlowNode, timerDefinition: TimerEventDefinition, callback: Function): Subscription;
+  initializeTimerFromDefinition(
+    flowNode: Model.Base.FlowNode,
+    timerDefinition: TimerEventDefinition,
+    token: ProcessToken,
+    callback: Function,
+  ): Subscription;
 
   /**
    * Takes an event definition and parsed it into a comprehensive


### PR DESCRIPTION
**Changes:**

Add `initializeTimerFromDefinition` to `ITimerFacade`, to allow a user to create timer subscriptions based on a given TimerEventDefinition.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/249

PR: #105

## How can others test the changes?

Implement the `ITimerFacade` interface and see that it now provides the aforementioned method.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).