### PR TITLE
♻️ Refactor expected parameters for process execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "40.0.0",
+  "version": "40.1.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/engine/iexecute_process_service.ts
+++ b/src/runtime/engine/iexecute_process_service.ts
@@ -1,7 +1,6 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {EndEventReachedMessage, ProcessStartedMessage} from '../messages';
-import {Model} from './../../model';
 
 /**
  * This service handles the execution of ProcessModels.
@@ -17,7 +16,7 @@ export interface IExecuteProcessService {
    *
    * @async
    * @param identity       The requesting users identity.
-   * @param processModel   The ProcessModel to execute.
+   * @param processModelId The ID of the ProcessModel to execute.
    * @param startEventId   The ID of the StartEvent by which to start the
    *                       ProcessModel.
    * @param correlationId  The CorrelationId to use.
@@ -26,12 +25,14 @@ export interface IExecuteProcessService {
    * @param caller         Optional: If a Subprocess is started, this will
    *                       contain the ID of the parent Process.
    */
-  start(identity: IIdentity,
-        processModel: Model.Types.Process,
-        startEventId: string,
-        correlationId: string,
-        initialPayload?: any,
-        caller?: string): Promise<ProcessStartedMessage>;
+  start(
+    identity: IIdentity,
+    processModelId: string,
+    startEventId: string,
+    correlationId: string,
+    initialPayload?: any,
+    caller?: string,
+  ): Promise<ProcessStartedMessage>;
 
   /**
    * Executes a ProcessModel.
@@ -39,7 +40,7 @@ export interface IExecuteProcessService {
    *
    * @async
    * @param identity       The requesting users identity.
-   * @param processModel   The ProcessModel to execute.
+   * @param processModelId The ID of the ProcessModel to execute.
    * @param startEventId   The ID of the StartEvent by which to start the
    *                       ProcessModel.
    * @param correlationId  The CorrelationId to use.
@@ -48,12 +49,14 @@ export interface IExecuteProcessService {
    * @param caller         Optional: If a Subprocess is started, this will
    *                       contain the ID of the parent Process.
    */
-  startAndAwaitEndEvent(identity: IIdentity,
-                        processModel: Model.Types.Process,
-                        startEventId: string,
-                        correlationId: string,
-                        initialPayload?: any,
-                        caller?: string): Promise<EndEventReachedMessage>;
+  startAndAwaitEndEvent(
+    identity: IIdentity,
+    processModelId: string,
+    startEventId: string,
+    correlationId: string,
+    initialPayload?: any,
+    caller?: string,
+  ): Promise<EndEventReachedMessage>;
 
   /**
    * Executes a ProcessModel.
@@ -61,7 +64,7 @@ export interface IExecuteProcessService {
    *
    * @async
    * @param identity       The requesting users identity.
-   * @param processModel   The ProcessModel to execute.
+   * @param processModelId The ID of the ProcessModel to execute.
    * @param startEventId   The ID of the StartEvent by which to start the
    *                       ProcessModel.
    * @param correlationId  The CorrelationId to use.
@@ -71,11 +74,13 @@ export interface IExecuteProcessService {
    * @param caller         Optional: If a Subprocess is started, this will
    *                       contain the ID of the parent Process.
    */
-  startAndAwaitSpecificEndEvent(identity: IIdentity,
-                                processModel: Model.Types.Process,
-                                startEventId: string,
-                                correlationId: string,
-                                endEventId: string,
-                                initialPayload?: any,
-                                caller?: string): Promise<EndEventReachedMessage>;
+  startAndAwaitSpecificEndEvent(
+    identity: IIdentity,
+    processModelId: string,
+    startEventId: string,
+    correlationId: string,
+    endEventId: string,
+    initialPayload?: any,
+    caller?: string,
+  ): Promise<EndEventReachedMessage>;
 }


### PR DESCRIPTION
**Changes:**

1. The `start` methods on the `IExecuteProcessService` no longer expect a full ProcessModel, but only a ProcessModelId.
2. This removes the need for external services to retrieve full ProcessModels themselves. Instead, the `ExecuteProcessService` can do that by itself, thereby guaranteeing that it has all necessary infos about the ProcessModel.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/253

PR: #107

## How can others test the changes?

Implement the `IExecuteProcessService` interface somewhere.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).