### PR TITLE
♻️ Make the StartEvent Id on the Starter Methods Optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "40.2.0",
+  "version": "41.0.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/engine/iexecute_process_service.ts
+++ b/src/runtime/engine/iexecute_process_service.ts
@@ -17,10 +17,10 @@ export interface IExecuteProcessService {
    * @async
    * @param identity       The requesting users identity.
    * @param processModelId The ID of the ProcessModel to execute.
-   * @param startEventId   The ID of the StartEvent by which to start the
-   *                       ProcessModel.
    * @param correlationId  The CorrelationId to use.
    *                       If not provided, it will be generated.
+   * @param startEventId   The ID of the StartEvent by which to start the
+   *                       ProcessModel.
    * @param initialPayload The payload to pass to the StartEvent.
    * @param caller         Optional: If a Subprocess is started, this will
    *                       contain the ID of the parent Process.
@@ -28,8 +28,8 @@ export interface IExecuteProcessService {
   start(
     identity: IIdentity,
     processModelId: string,
-    startEventId: string,
     correlationId: string,
+    startEventId?: string,
     initialPayload?: any,
     caller?: string,
   ): Promise<ProcessStartedMessage>;
@@ -41,10 +41,10 @@ export interface IExecuteProcessService {
    * @async
    * @param identity       The requesting users identity.
    * @param processModelId The ID of the ProcessModel to execute.
-   * @param startEventId   The ID of the StartEvent by which to start the
-   *                       ProcessModel.
    * @param correlationId  The CorrelationId to use.
    *                       If not provided, it will be generated.
+   * @param startEventId   The ID of the StartEvent by which to start the
+   *                       ProcessModel.
    * @param initialPayload The payload to pass to the StartEvent.
    * @param caller         Optional: If a Subprocess is started, this will
    *                       contain the ID of the parent Process.
@@ -52,8 +52,8 @@ export interface IExecuteProcessService {
   startAndAwaitEndEvent(
     identity: IIdentity,
     processModelId: string,
-    startEventId: string,
     correlationId: string,
+    startEventId?: string,
     initialPayload?: any,
     caller?: string,
   ): Promise<EndEventReachedMessage>;
@@ -65,11 +65,11 @@ export interface IExecuteProcessService {
    * @async
    * @param identity       The requesting users identity.
    * @param processModelId The ID of the ProcessModel to execute.
-   * @param startEventId   The ID of the StartEvent by which to start the
-   *                       ProcessModel.
    * @param correlationId  The CorrelationId to use.
    *                       If not provided, it will be generated.
    * @param endEventId     The ID of the EndEvent to wait for.
+   * @param startEventId   The ID of the StartEvent by which to start the
+   *                       ProcessModel.
    * @param initialPayload The payload to pass to the StartEvent.
    * @param caller         Optional: If a Subprocess is started, this will
    *                       contain the ID of the parent Process.
@@ -77,10 +77,10 @@ export interface IExecuteProcessService {
   startAndAwaitSpecificEndEvent(
     identity: IIdentity,
     processModelId: string,
-    startEventId: string,
     correlationId: string,
     endEventId: string,
     initialPayload?: any,
+    startEventId?: string,
     caller?: string,
   ): Promise<EndEventReachedMessage>;
 }

--- a/src/runtime/engine/iexecute_process_service.ts
+++ b/src/runtime/engine/iexecute_process_service.ts
@@ -79,8 +79,8 @@ export interface IExecuteProcessService {
     processModelId: string,
     correlationId: string,
     endEventId: string,
-    initialPayload?: any,
     startEventId?: string,
+    initialPayload?: any,
     caller?: string,
   ): Promise<EndEventReachedMessage>;
 }

--- a/src/runtime/engine/iprocess_model_facade.ts
+++ b/src/runtime/engine/iprocess_model_facade.ts
@@ -23,10 +23,10 @@ export interface IProcessModelFacade {
 
   /**
    * Gets a single StartEvent, if the process does not contain more
-   * then one start events.
+   * than one StartEvent.
    *
    * @returns The only StartEvent of the Process
-   * @throws BadRequestError If the Process contains more then one StartEvents.
+   * @throws {BadRequestError} If the Process contains more than one StartEvent.
    */
   getSingleStartEvent(): Model.Events.StartEvent;
 

--- a/src/runtime/engine/iprocess_model_facade.ts
+++ b/src/runtime/engine/iprocess_model_facade.ts
@@ -22,11 +22,11 @@ export interface IProcessModelFacade {
   getStartEvents(): Array<StartEvent>;
 
   /**
-   * Gets a single StartEvent, if the process does not contain more
-   * than one StartEvent.
+   * Gets the first StartEvent of the ProcessModel.
+   * Should only be used for ProcessModels that only
+   * have one StartEvent.
    *
-   * @returns The only StartEvent of the Process
-   * @throws {BadRequestError} If the Process contains more than one StartEvent.
+   * @returns The first StartEvent of the ProcessModel.
    */
   getSingleStartEvent(): StartEvent;
 

--- a/src/runtime/engine/iprocess_model_facade.ts
+++ b/src/runtime/engine/iprocess_model_facade.ts
@@ -28,7 +28,7 @@ export interface IProcessModelFacade {
    * @returns The only StartEvent of the Process
    * @throws {BadRequestError} If the Process contains more than one StartEvent.
    */
-  getSingleStartEvent(): Model.Events.StartEvent;
+  getSingleStartEvent(): StartEvent;
 
   /**
    * Gets a StartEvent by its ID.

--- a/src/runtime/engine/iprocess_model_facade.ts
+++ b/src/runtime/engine/iprocess_model_facade.ts
@@ -22,6 +22,15 @@ export interface IProcessModelFacade {
   getStartEvents(): Array<StartEvent>;
 
   /**
+   * Gets a single StartEvent, if the process does not contain more
+   * then one start events.
+   *
+   * @returns The only StartEvent of the Process
+   * @throws BadRequestError If the Process contains more then one StartEvents.
+   */
+  getSingleStartEvent(): Model.Events.StartEvent;
+
+  /**
    * Gets a StartEvent by its ID.
    *
    * @param startEventId The ID of the StartEvent to get.


### PR DESCRIPTION
**Changes:**

1. Makes the StartEventId on the starter Methods optional. If a Process contains only one StartEvent, its not necessary anymore to provide a StartEvent id.
2. Add a convenience Method to pick the StartEvent, if the Process does only contains one StartEvent.

**Issues:**

Related: https://github.com/process-engine/process_engine_runtime/issues/252

PR: #108

## How can others test the changes?

Implement the new interfaces for the ExecuteProcessService and the ProcessModelFacade.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).