### PR TITLE
✨ Add EndEvent name and ID to CallActivity result

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "41.1.0",
+  "version": "41.2.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/messages/bpmn_events/base_bpmn_event_message.ts
+++ b/src/runtime/messages/bpmn_events/base_bpmn_event_message.ts
@@ -10,6 +10,7 @@ export class BaseBpmnEventMessage {
   public readonly processModelId: string;
   public readonly processInstanceId: string;
   public readonly flowNodeId: string;
+  public readonly flowNodeName: string;
   public readonly flowNodeInstanceId: string;
   public readonly processInstanceOwner: IIdentity;
   public readonly currentToken: any;
@@ -20,7 +21,8 @@ export class BaseBpmnEventMessage {
               flowNodeId: string,
               flowNodeInstanceId: string,
               processInstanceOwner: IIdentity,
-              currentToken: any) {
+              currentToken: any,
+              flowNodeName?: string) {
     this.correlationId = correlationId;
     this.processModelId = processModelId;
     this.processInstanceId = processInstanceId;
@@ -28,5 +30,6 @@ export class BaseBpmnEventMessage {
     this.flowNodeInstanceId = flowNodeInstanceId;
     this.processInstanceOwner = processInstanceOwner;
     this.currentToken = currentToken;
+    this.flowNodeName = flowNodeName;
   }
 }

--- a/src/runtime/messages/bpmn_events/end_event_reached.ts
+++ b/src/runtime/messages/bpmn_events/end_event_reached.ts
@@ -8,13 +8,20 @@ import {BaseBpmnEventMessage} from './base_bpmn_event_message';
  */
 export class EndEventReachedMessage extends BaseBpmnEventMessage {
 
+  /**
+   * The name of the EndEvent that was reached.
+   */
+  public endEventName: string;
+
   constructor(correlationId: string,
               processModelId: string,
               processInstanceId: string,
               flowNodeId: string,
               flowNodeInstanceId: string,
               processInstanceOwner: IIdentity,
-              currentToken: any) {
+              currentToken: any,
+              endEventName?: string) {
     super(correlationId, processModelId, processInstanceId, flowNodeId, flowNodeInstanceId, processInstanceOwner, currentToken);
+    this.endEventName = endEventName;
   }
 }

--- a/src/runtime/messages/bpmn_events/end_event_reached.ts
+++ b/src/runtime/messages/bpmn_events/end_event_reached.ts
@@ -8,11 +8,6 @@ import {BaseBpmnEventMessage} from './base_bpmn_event_message';
  */
 export class EndEventReachedMessage extends BaseBpmnEventMessage {
 
-  /**
-   * The name of the EndEvent that was reached.
-   */
-  public endEventName: string;
-
   constructor(correlationId: string,
               processModelId: string,
               processInstanceId: string,
@@ -21,7 +16,6 @@ export class EndEventReachedMessage extends BaseBpmnEventMessage {
               processInstanceOwner: IIdentity,
               currentToken: any,
               endEventName?: string) {
-    super(correlationId, processModelId, processInstanceId, flowNodeId, flowNodeInstanceId, processInstanceOwner, currentToken);
-    this.endEventName = endEventName;
+    super(correlationId, processModelId, processInstanceId, flowNodeId, flowNodeInstanceId, processInstanceOwner, currentToken, endEventName);
   }
 }

--- a/src/runtime/messages/bpmn_events/message_event_reached.ts
+++ b/src/runtime/messages/bpmn_events/message_event_reached.ts
@@ -17,8 +17,9 @@ export class MessageEventReachedMessage extends BaseBpmnEventMessage {
               flowNodeId: string,
               flowNodeInstanceId: string,
               processInstanceOwner: IIdentity,
-              currentToken: any) {
-    super(correlationId, processModelId, processInstanceId, flowNodeId, flowNodeInstanceId, processInstanceOwner, currentToken);
+              currentToken: any,
+              messageEventName?: string) {
+    super(correlationId, processModelId, processInstanceId, flowNodeId, flowNodeInstanceId, processInstanceOwner, currentToken, messageEventName);
 
     this.messageReference = messageReference;
   }

--- a/src/runtime/messages/bpmn_events/signal_event_reached.ts
+++ b/src/runtime/messages/bpmn_events/signal_event_reached.ts
@@ -17,8 +17,9 @@ export class SignalEventReachedMessage extends BaseBpmnEventMessage {
               flowNodeId: string,
               flowNodeInstanceId: string,
               processInstanceOwner: IIdentity,
-              currentToken: any) {
-    super(correlationId, processModelId, processInstanceId, flowNodeId, flowNodeInstanceId, processInstanceOwner, currentToken);
+              currentToken: any,
+              signalEventName?: string) {
+    super(correlationId, processModelId, processInstanceId, flowNodeId, flowNodeInstanceId, processInstanceOwner, currentToken, signalEventName);
 
     this.signalReference = signalReference;
   }

--- a/src/runtime/messages/bpmn_events/terminate_end_event_reached.ts
+++ b/src/runtime/messages/bpmn_events/terminate_end_event_reached.ts
@@ -8,11 +8,6 @@ import {BaseBpmnEventMessage} from './base_bpmn_event_message';
  */
 export class TerminateEndEventReachedMessage extends BaseBpmnEventMessage {
 
-  /**
-   * The name of the EndEvent that was reached.
-   */
-  public endEventName: string;
-
   constructor(correlationId: string,
               processModelId: string,
               processInstanceId: string,
@@ -21,7 +16,6 @@ export class TerminateEndEventReachedMessage extends BaseBpmnEventMessage {
               processInstanceOwner: IIdentity,
               currentToken: any,
               endEventName?: string) {
-    super(correlationId, processModelId, processInstanceId, flowNodeId, flowNodeInstanceId, processInstanceOwner, currentToken);
-    this.endEventName = endEventName;
+    super(correlationId, processModelId, processInstanceId, flowNodeId, flowNodeInstanceId, processInstanceOwner, currentToken, endEventName);
   }
 }

--- a/src/runtime/messages/bpmn_events/terminate_end_event_reached.ts
+++ b/src/runtime/messages/bpmn_events/terminate_end_event_reached.ts
@@ -8,13 +8,20 @@ import {BaseBpmnEventMessage} from './base_bpmn_event_message';
  */
 export class TerminateEndEventReachedMessage extends BaseBpmnEventMessage {
 
+  /**
+   * The name of the EndEvent that was reached.
+   */
+  public endEventName: string;
+
   constructor(correlationId: string,
               processModelId: string,
               processInstanceId: string,
               flowNodeId: string,
               flowNodeInstanceId: string,
               processInstanceOwner: IIdentity,
-              currentToken: any) {
+              currentToken: any,
+              endEventName?: string) {
     super(correlationId, processModelId, processInstanceId, flowNodeId, flowNodeInstanceId, processInstanceOwner, currentToken);
+    this.endEventName = endEventName;
   }
 }


### PR DESCRIPTION
**Changes:**

Add an optional `eventName` parameter to BpmnEvent messages.
The property is optional, because it is only supposed to be provided by EndEvents.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/280

PR: #111

## How can others test the changes?

Use the new messages to send notifications for EndEvents.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).