### PR TITLE
✨Cyclic TimerStartEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,20 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
-  "contributors": [
+  "author": "5Minds IT-Solutions GmbH & Co. KG",
+  "maintainers": [
+    "Alexander Kasten <alexander.kasten@5minds.de>",
     "Christian Werner <christian.werner@5minds.de>",
+    "René Föhring <rene.foehring@5minds.de>",
+    "Steffen Knaup <steffen.knaup@5minds.de>"
+  ],
+  "contributors": [
+    "Bastian Schnittger <bastian.schnittger@5minds.de>",
+    "Christoph Gnip <christoph.gnip@5minds.de>",
+    "Paul Heidenreich <paul.heidenreich@5minds.de>",
+    "Robin Lenz <robin.lenz@5minds.de>",
+    "Heiko Mathes <heiko.mathes@5minds.de>",
+    "Robin Palkovits <robin.palkovits@5minds.de>",
     "Sebastian Meier <sebastian.meier@5minds.de>"
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "45.0.0",
+  "version": "45.1.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/model_duplications/flow_nodes/definitions/timer_event_definition.ts
+++ b/src/model_duplications/flow_nodes/definitions/timer_event_definition.ts
@@ -2,6 +2,7 @@ import {EventDefinition} from './event_definition';
 
 export class TimerEventDefinition extends EventDefinition {
 
+  public enabled?: boolean = true;
   public timerType: TimerType;
 
 }

--- a/src/runtime/engine/services/icronjob_service.ts
+++ b/src/runtime/engine/services/icronjob_service.ts
@@ -1,0 +1,32 @@
+import {Process} from '../../../model_duplications/process/process';
+
+import {IAutoStartService} from './iauto_start_service';
+
+/**
+ * This service is responsible for starting ProcessModels that make use of
+ * cyclic TimerStartEvents.
+ *
+ * This is achieved by creating a cronjob for each unique cyclic timer definition.
+ * When such a cronjob expires, all ProcessModels with a matching TimerStartEvent
+ * will be triggered.
+ */
+export interface ICronjobService extends IAutoStartService {
+
+  /**
+   * Adds the cyclic TimerStartEvents of the given ProcessModel to the internal
+   * cronjob storage, or updates it, if the ProcessModel has already been added
+   * to the list.
+   *
+   * @param processModel
+   */
+  addOrUpdate(processModel: Process): void;
+
+  /**
+   * Removes the given ProcessModelId from the internal cronjob storage.
+   * All orphaned cronjobs (i.e. cronjobs that no longer trigger any ProcessModels)
+   * will be cleaned up as well.
+   *
+   * @param processModelId
+   */
+  remove(processModelId: string): void;
+}

--- a/src/runtime/engine/services/index.ts
+++ b/src/runtime/engine/services/index.ts
@@ -1,3 +1,4 @@
 export * from './iauto_start_service';
+export * from './icronjob_service';
 export * from './iexecute_process_service';
 export * from './iresume_process_service';


### PR DESCRIPTION
## Changes

1. Add interface for `ICronjobService`
    - The interface is derived from the `IAutostartService`
    - It provides additional methods for adding and removing timers for a specific ProcessModel
2. Add optional `enabled` property to `TimerEventDefintion` with a default value of `true`

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/118

PR: #122
