### PR TITLE
✨Add getActiveCronjobs UseCase

### DIFF
--- a/src/runtime/engine/services/icronjob_service.ts
+++ b/src/runtime/engine/services/icronjob_service.ts
@@ -13,6 +13,14 @@ import {IAutoStartService} from './iauto_start_service';
 export interface ICronjobService extends IAutoStartService {
 
   /**
+   * Gets a list of all cronjobs that are currently active.
+   * The cronjobs are grouped by the ProcessModel to which they belong.
+   *
+   * @returns A list of active Cronjobs.
+   */
+  getActive(): Array<CronjobConfiguration>;
+
+  /**
    * Adds the cyclic TimerStartEvents of the given ProcessModel to the internal
    * cronjob storage, or updates it, if the ProcessModel has already been added
    * to the list.
@@ -29,4 +37,13 @@ export interface ICronjobService extends IAutoStartService {
    * @param processModelId
    */
   remove(processModelId: string): void;
+}
+
+/**
+ * Describes a cronjob employed by the CronjobService.
+ */
+export type CronjobConfiguration = {
+  processModelId: string;
+  startEventId: string;
+  cronjob: string;
 }

--- a/src/runtime/engine/services/icronjob_service.ts
+++ b/src/runtime/engine/services/icronjob_service.ts
@@ -43,7 +43,16 @@ export interface ICronjobService extends IAutoStartService {
  * Describes a cronjob employed by the CronjobService.
  */
 export type CronjobConfiguration = {
+  /**
+   * The ID of the ProcessModel that contains the cronjob.
+   */
   processModelId: string;
+  /**
+   * The ID of the StartEvent that contains the cronjob.
+   */
   startEventId: string;
-  cronjob: string;
+  /**
+   * The crontab that describs the cronjob.
+   */
+  crontab: string;
 }

--- a/src/runtime/engine/services/icronjob_service.ts
+++ b/src/runtime/engine/services/icronjob_service.ts
@@ -55,4 +55,8 @@ export type CronjobConfiguration = {
    * The crontab that describs the cronjob.
    */
   crontab: string;
+  /**
+   * The next time the cronjob will be triggered.
+   */
+  nextExecution: Date;
 }


### PR DESCRIPTION
## Changes

1. Add `getActive` to `ICronjobService` interface
2. Add public type for describing a cronjob.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/363

PR: #123
