### PR TITLE
♻️ Improve TimerFacade and TimerDefinition parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "6.0.0",
+  "version": "46.0.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "45.1.1",
+  "version": "6.0.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,21 +34,3 @@ export enum EventType {
   timerEvent = 'timerEvent',
   errorEvent = 'errorEvent',
 }
-
-/**
- * Contains a list of possible timer definition types.
- */
-export enum TimerDefinitionType {
-  /**
-   * The timer will run once and expire at the given date and time.
-   */
-  date = 0,
-  /**
-   * The timer will run once and expire after a given amount of time.
-   */
-  duration = 1,
-  /**
-   * The timer will run repeatedly in the given interval.
-   */
-  cycle = 2,
-}

--- a/src/model_duplications/flow_nodes/definitions/timer_event_definition.ts
+++ b/src/model_duplications/flow_nodes/definitions/timer_event_definition.ts
@@ -4,6 +4,7 @@ export class TimerEventDefinition extends EventDefinition {
 
   public enabled?: boolean = true;
   public timerType: TimerType;
+  public value: string;
 
 }
 

--- a/src/runtime/engine/facades/itimer_facade.ts
+++ b/src/runtime/engine/facades/itimer_facade.ts
@@ -1,6 +1,6 @@
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 
-import {FlowNode, TimerEventDefinition} from '../../../model_duplications/index';
+import {FlowNode, TimerEventDefinition, TimerType} from '../../../model_duplications/index';
 
 import {IProcessTokenFacade} from './iprocess_token_facade';
 
@@ -58,6 +58,14 @@ export interface ITimerFacade {
    * @returns                       The Subscription that was created on the EventAggregator.
    */
   startDurationTimer(duration: string, callback: Function, timerExpiredEventName?: string): Subscription;
+
+  /**
+   * Validates the given TimerType and TimerValue, using the given FlowNode as a baseline.
+   *
+   * @param timerDefinition The definition of the timer to validate.
+   * @param flowNode        The FlowNode to use as a baseline.
+   */
+  validateTimer(timerDefinition: TimerEventDefinition, flowNode: FlowNode): void;
 
   /**
    * Takes a timer expression and a ProcessTokenFacade and checks if the timerExpression contains

--- a/src/runtime/engine/facades/itimer_facade.ts
+++ b/src/runtime/engine/facades/itimer_facade.ts
@@ -1,7 +1,6 @@
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 
 import {FlowNode, TimerEventDefinition} from '../../../model_duplications/index';
-import {TimerDefinitionType} from '../../../constants';
 
 import {IProcessTokenFacade} from './iprocess_token_facade';
 
@@ -14,56 +13,63 @@ export interface ITimerFacade {
    * Initializes a new timer for the given FlowNode, using the given type and
    * value as a baseline.
    *
-   * @param   flowNode           The FlowNode to which to attach the timer.
-   * @param   timerType          The type of the timer (cycle, duration, etc).
-   * @param   timerValue         The value of the timer.
-   * @param   callback           The function to call, after the timer has elapsed.
-   * @returns                    A Subscription on the event aggreator,
-   *                             which can be used to wait for the timer to elapse.
+   * @param   flowNode        The FlowNode to which to attach the timer.
+   * @param   timerDefinition The definition containing the timer.
+   * @param   callback        The function to call, after the timer has elapsed.
+   * @returns                 A Subscription on the event aggreator,
+   *                          which can be used to wait for the timer to elapse.
    */
   initializeTimer(
     flowNode: FlowNode,
-    timerType: TimerDefinitionType,
-    timerValue: string,
-    callback: Function,
-  ): Subscription;
-
-  /**
-   * Initializes a new timer for the given FlowNode from the given
-   * timerDefinition.
-   *
-   * @param   flowNode           The FlowNode to which to attach the timer.
-   * @param   timerDefinition    The timer definition from which to build the timer.
-   * @param   processTokenFacade The ProcessTokenFacade to use to retrieve
-   *                             token values for timer expressions.
-   * @param   callback           The function to call, after the timer has elapsed.
-   * @returns                    A Subscription on the event aggreator,
-   *                             which can be used to wait for the timer to elapse.
-   */
-  initializeTimerFromDefinition(
-    flowNode: FlowNode,
     timerDefinition: TimerEventDefinition,
-    processTokenFacade: IProcessTokenFacade,
     callback: Function,
   ): Subscription;
 
   /**
-   * Takes an event definition and parsed it into a comprehensive
-   * TimerDefinitionType.
+   * Initializes a new cyclic timer, using the given value and FlowNode.
+   * When the timer expires, the given callback will be called.
    *
-   * @param   eventDefinition The event definition to parse.
-   * @returns                 The parsed TimerDefinitionType.
+   * @param   crontab               The crontab to use.
+   * @param   flowNode              The FlowNode that contains the timer.
+   * @param   callback              The callback to call, when the timer expires.
+   * @param   timerExpiredEventName Optional: A name for the event to raise, when the timer expires.
+   * @returns                       The Subscription that was created on the EventAggregator.
    */
-  parseTimerDefinitionType(eventDefinition: TimerEventDefinition): TimerDefinitionType;
+  startCycleTimer(crontab: string, flowNode: FlowNode, callback: Function, timerExpiredEventName?: string): Subscription;
 
   /**
-   * Takes the given event definition and parses the attached value into
-   * a format that can be understood be the timer-scheduling library.
+   * Initializes a new date timer, using the given value.
+   * When the timer expires, the given callback will be called.
    *
-   * @param   eventDefinition The event definition to parse.
-   * @returns                 The parsed timer value.
+   * @param   date                  The date at which the timer will be triggered.
+   * @param   callback              The callback to call, when the timer expires.
+   * @param   timerExpiredEventName Optional: A name for the event to raise, when the timer expires.
+   * @returns                       The Subscription that was created on the EventAggregator.
    */
-  parseTimerDefinitionValue(eventDefinition: TimerEventDefinition): string;
+  startDateTimer(date: string, callback: Function, timerExpiredEventName?: string): Subscription;
+
+  /**
+   * Initializes a new duration timer, using the given value.
+   * When the timer expires, the given callback will be called.
+   *
+   * @param   duration              The duration to use.
+   * @param   callback              The callback to call, when the timer expires.
+   * @param   timerExpiredEventName Optional: A name for the event to raise, when the timer expires.
+   * @returns                       The Subscription that was created on the EventAggregator.
+   */
+  startDurationTimer(duration: string, callback: Function, timerExpiredEventName?: string): Subscription;
+
+  /**
+   * Takes a timer expression and a ProcessTokenFacade and checks if the timerExpression contains
+   * references to the ProcessToken (i.e. token.history.FlowNode1.abc and the like).
+   * If so, these references will be resolved with values from the current ProcessToken,
+   * contained within the facade.
+   *
+   * @param   timerExpression    The timer expression to parse.
+   * @param   processTokenFacade The facade containing the current ProcessToken.
+   * @returns                    The parsed timer expression.
+   */
+  executeTimerExpressionIfNeeded(timerExpression: string, processTokenFacade: IProcessTokenFacade): string;
 
   /**
    * Cancels the given timer subscription.

--- a/src/runtime/engine/facades/itimer_facade.ts
+++ b/src/runtime/engine/facades/itimer_facade.ts
@@ -13,15 +13,17 @@ export interface ITimerFacade {
    * Initializes a new timer for the given FlowNode, using the given type and
    * value as a baseline.
    *
-   * @param   flowNode        The FlowNode to which to attach the timer.
-   * @param   timerDefinition The definition containing the timer.
-   * @param   callback        The function to call, after the timer has elapsed.
-   * @returns                 A Subscription on the event aggreator,
-   *                          which can be used to wait for the timer to elapse.
+   * @param   flowNode           The FlowNode to which to attach the timer.
+   * @param   timerDefinition    The definition containing the timer.
+   * @param   processTokenFacade The facade containing the current ProcessToken.
+   * @param   callback           The function to call, after the timer has elapsed.
+   * @returns                    A Subscription on the event aggreator,
+   *                             which can be used to wait for the timer to elapse.
    */
   initializeTimer(
     flowNode: FlowNode,
     timerDefinition: TimerEventDefinition,
+    processTokenFacade: IProcessTokenFacade,
     callback: Function,
   ): Subscription;
 


### PR DESCRIPTION
## Changes

1. Remove duplicated `TimerDefinitionType`
2. Add `value` to `TimerEventDefinition` type
3. Refactor `ITimerFacade`:
    - Remove `initializeTimerFromDefinition`, `parseTimerDefinitionType` and `parseTimerDefinitionValue`
    - Add `startCycleTimer`, `startDateTimer`, `startDurationTimer`, `validateTimer` and `executeTimerExpressionIfNeeded` 
    - Expect a full TimerEventDefinition and a ProcessTokenFacade in `initializeTimer`, instead of separate values for TimerType and TimerValue

## Issues

PR: #125
