### PR TITLE
🔒 Use correct identity for terminating ProcessInstances manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "46.0.3",
+  "version": "46.1.0",
   "description": "The referencable contracts for the whole ProcessEngine.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/engine/flow_node_handler/iinterruptible.ts
+++ b/src/runtime/engine/flow_node_handler/iinterruptible.ts
@@ -3,11 +3,18 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {ProcessToken} from '../../types/process_token';
 
 /**
+ * When a ProcessInstance gets terminated manually, this will contain the identity of the terminating user.
+ */
+export type ManualTerminationMessage = {
+  terminatedBy: IIdentity;
+};
+
+/**
  * The signature for the interruption callback function.
  * This callback can be used by the derived FlowNodeHandlers to perform cleanup
  * operations after being interrupted.
  */
-export type onInterruptionCallback = (interruptionToken: ProcessToken) => void | Promise<void>;
+export type onInterruptionCallback = (currentToken: ProcessToken) => void | Promise<void>;
 
 /**
  * Contains function definitions for interrupting a FlowNodeHandler.

--- a/src/runtime/engine/flow_node_handler/iinterruptible.ts
+++ b/src/runtime/engine/flow_node_handler/iinterruptible.ts
@@ -1,3 +1,5 @@
+import {IIdentity} from '@essential-projects/iam_contracts';
+
 import {ProcessToken} from '../../types/process_token';
 
 /**
@@ -20,5 +22,5 @@ export interface IInterruptible {
    * @param terminate Optional: If set to true, the activity will terminate,
    *                  rather than finish regularily.
    */
-  interrupt(token: ProcessToken, terminate?: boolean): void | Promise<void>;
+  interrupt(token: ProcessToken, terminate?: boolean, terminatedBy?: IIdentity): void | Promise<void>;
 }


### PR DESCRIPTION
## Changes

1. Add `ManualTerminationMessage` type
    - This type can be used for messages sent when a ProcessInstance is terminated by a user
2. Add `terminatedBy` as optional parameter to `interrupt` signature

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/474

PR: #127